### PR TITLE
Adjust spec sections to align with IETF specs

### DIFF
--- a/spec/about.md
+++ b/spec/about.md
@@ -1,8 +1,0 @@
-## About
-
-This open specification is based on the open source
-verifiable credential implementation of AnonCreds that has been in use since 2017 as part of
-the [Hyperledger Indy](https://www.hyperledger.org/projects/hyperledger-indy)
-open source project. The extensive use of AnonCreds around the world has made it a de facto
-standard, and the AnonCreds Working Group (AnonCreds-WG) has been established to formalize the
-specification and place it on a standards track.

--- a/spec/abstract.md
+++ b/spec/abstract.md
@@ -1,17 +1,8 @@
 ## Abstract
 
-AnonCreds verifiable credentials provide capabilities that many see as important for digital identity use cases in particular, and verifiable data in general. These features include:
-
-- A full implementation of the Layer 3 verifiable credential “Trust Triangle” of the [Trust over IP Model](https://trustoverip.org/wp-content/toip-model/).
-- Complete flows for issuing verifiable credentials (Issuer to Holder), and requesting, generating and verifying presentations of verifiable claims (Holder to Verifier).
-- Fully defined data models for all of the objects in the flows, including verifiable credentials, presentation requests and presentations sourced from multiple credentials.
-- Fully defined applications of cryptographic primitives.
-- The use of Zero Knowledge Proofs (ZKPs) in the verifiable presentation process to enhance the privacy protections available to the holder in presenting data to verifiers, including:
-  - Blinding issuer signatures to prevent correlation based on those signatures.
-  - The use of unrevealed identifiers for holder binding to prevent correlation based on such identifiers.
-  - The use of predicate proofs to reduce the sharing of PII and potentially correlating data, especially dates (birth, credential issuance/expiry, etc.).
-  - A revocation scheme that proves a presentation is based on credentials that have not been revoked by the issuers without revealing correlatable revocation identifiers.
-
-The AnonCreds v0.1 Specification matches the existing [Hyperledger Indy SDK (“libindy”)](https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/api/anoncreds.rs) and [Indy Credential Exchange (“cred-x”)](https://github.com/hyperledger/indy-shared-rs/tree/main/indy-credx) implementations.
-
-The next version of the specification, v1.0 will remove from the v0.1 specification any dependence on Hyperledger Indy by removing any requirements related to the storage of the objects used in AnonCreds, whether they be stored remotely on a “verifiable data registry” (including Hyperledger Indy) or in local secure storage.
+Th AnonCreds specification is based on the open source verifiable credential
+implementation of AnonCreds that has been in use since 2017 as part of the
+[Hyperledger Indy](https://www.hyperledger.org/projects/hyperledger-indy) open
+source project. The extensive use of AnonCreds around the world has made it a de
+facto standard for ZKP-based verifiable credentials, and this specification is the
+formalization of that implementation.

--- a/spec/acknowledgements_authors.md
+++ b/spec/acknowledgements_authors.md
@@ -7,8 +7,14 @@ This specification is the work of the AnonCreds Working Group, which includes do
 of active and dedicated participants.  In particular, the following individuals
 contributed ideas, feedback, and wording that influenced this specification:
 
-To Be Determined.
+::: todo
+Add list of contributors.
+:::
+
 
 ## Authors' Addresses
 
-To be added.
+::: todo
+Add authors' addresses.
+:::
+

--- a/spec/acknowledgements_authors.md
+++ b/spec/acknowledgements_authors.md
@@ -1,0 +1,14 @@
+## Acknowledgements
+
+AnonCreds was initially created as part of the Open Source Hyperledger
+Indy project.
+
+This specification is the work of the AnonCreds Working Group, which includes dozens
+of active and dedicated participants.  In particular, the following individuals
+contributed ideas, feedback, and wording that influenced this specification:
+
+To Be Determined.
+
+## Authors' Addresses
+
+To be added.

--- a/spec/iana_considerations.md
+++ b/spec/iana_considerations.md
@@ -1,0 +1,3 @@
+## IANA Considerations
+
+This document has no IANA actions.

--- a/spec/informative_references.md
+++ b/spec/informative_references.md
@@ -1,0 +1,5 @@
+### Informative References
+
+::: todo
+Add informative references
+:::

--- a/spec/introduction.md
+++ b/spec/introduction.md
@@ -1,6 +1,17 @@
 ## Introduction
 
-::: todo
-Provide an introduction to AnonCreds using the same verifiable credential models of Figure 1 of the W3C.
-Question: Is this the same as the Abstract and so is not needed?
-:::
+AnonCreds ZKP verifiable credentials provide capabilities that many see as important for digital identity use cases in particular, and verifiable data in general. These features include:
+
+- A full implementation of the Layer 3 verifiable credential “Trust Triangle” of the [Trust over IP Model](https://trustoverip.org/wp-content/toip-model/).
+- Complete flows for issuing verifiable credentials (Issuer to Holder), and requesting, generating and verifying presentations of verifiable claims (Holder to Verifier).
+- Fully defined data models for all of the objects in the flows, including verifiable credentials, presentation requests and presentations sourced from multiple credentials.
+- Fully defined applications of cryptographic primitives.
+- The use of Zero Knowledge Proofs (ZKPs) in the verifiable presentation process to enhance the privacy protections available to the holder in presenting data to verifiers, including:
+  - Blinding issuer signatures to prevent correlation based on those signatures.
+  - The use of unrevealed identifiers for holder binding to prevent correlation based on such identifiers.
+  - The use of predicate proofs to reduce the sharing of PII and potentially correlating data, especially dates (birth, credential issuance/expiry, etc.).
+  - A revocation scheme that proves a presentation is based on credentials that have not been revoked by the issuers without revealing correlatable revocation identifiers.
+
+The AnonCreds v0.1 Specification matches the existing [Hyperledger Indy SDK (“libindy”)](https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/api/anoncreds.rs) and [Indy Credential Exchange (“cred-x”)](https://github.com/hyperledger/indy-shared-rs/tree/main/indy-credx) implementations.
+
+The next version of the specification (tentatively v1.0) will remove from the v0.1 specification any dependence on Hyperledger Indy by removing any requirements related to the storage of the objects used in AnonCreds, whether they be stored remotely on a “verifiable data registry” (including Hyperledger Indy) or in local secure storage.

--- a/spec/normative_references.md
+++ b/spec/normative_references.md
@@ -1,0 +1,7 @@
+## References
+
+### Normative References
+
+::: todo
+Add normative references
+:::

--- a/spec/privacy_considerations.md
+++ b/spec/privacy_considerations.md
@@ -1,0 +1,5 @@
+## Privacy Considerations
+
+::: todo
+Add privacy considerations.
+:::

--- a/spec/requirements_notations_conventions.md
+++ b/spec/requirements_notations_conventions.md
@@ -1,0 +1,7 @@
+## Requirements, Notation and Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+"MAY", and "OPTIONAL" in this document are to be interpreted as
+described in BCP 14 [RFC2119] [RFC8174] when, and only when, they
+appear in all capitals, as shown here.

--- a/spec/security_considerations.md
+++ b/spec/security_considerations.md
@@ -1,0 +1,5 @@
+## Security Considerations
+
+::: todo
+Add security considerations.
+:::

--- a/spec/status_copyright_toc.md
+++ b/spec/status_copyright_toc.md
@@ -1,0 +1,28 @@
+## Status of This Memo
+
+This is a pre-Internet Draft document.
+
+This document is a product of the [AnonCreds Working Group](https://github.com/AnonCreds-WG).
+It represents the consensus of the AnonCreds community.
+
+Information about the current status of this document, any errata,
+and how to provide feedback on it may be obtained at
+[https://github.com/AnonCreds-WG/anoncreds-spec](https://github.com/AnonCreds-WG/anoncreds-spec).
+
+## Copyright Notice
+
+This specifications is subject to the **Community Specification License 1.0**
+available at
+[https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+If source code is included in the specification, that code is subject to the
+Apache 2.0 license unless otherwise marked. In the case of any conflict or
+confusion within this specification between the Community Specification License
+and the designated source code license, the terms of the Community Specification
+License shall apply.
+
+## Table of Contents
+
+::: todo
+Table of Contents to be generated.
+:::

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -1,6 +1,6 @@
-## AnonCreds Glossary
+## Terminology
 
-A glossary of AnonCreds terms, including the objects that are used in the various AnonCreds operations (issue credential, generate proof, etc.).
+These terms are defined by this specification:
 
 [[def: Schema]]
 

--- a/specs.json
+++ b/specs.json
@@ -7,17 +7,20 @@
       "output_path": "./docs",
       "markdown_paths": [
         "header.md",
-        "about.md",
         "abstract.md",
-        "anoncreds_glossary.md",
+        "status_copyright_toc.md",
         "introduction.md",
+        "requirements_notations_conventions.md",
+        "terminology.md",
         "data_model_descriptions.md",
         "data_flow_setup.md",
         "data_flow_issuance.md",
         "data_flow_presentation.md",
         "data_flow_revocation.md",
         "anoncreds_conventions.md",
-        "appendix_data_models.md"
+        "normative_references.md",
+        "informative_references.md",
+        "acknowledgements_authors.md"
       ],
       "logo": "",
       "logo_link": "https://github.com/AnonCreds-WG/anoncreds-spec",

--- a/specs.json
+++ b/specs.json
@@ -18,6 +18,9 @@
         "data_flow_presentation.md",
         "data_flow_revocation.md",
         "anoncreds_conventions.md",
+        "iana_considerations.md",
+        "security_considerations.md",
+        "privacy_considerations.md",
         "normative_references.md",
         "informative_references.md",
         "acknowledgements_authors.md"


### PR DESCRIPTION
This PR updates the sections of the PR to better align with an IETF spec. This should make it easier to take the content and put it into an IETF spec tool in the future for submission as an Internet Draft.

Aside: I also submitted a request to the SpecUp tool to add an "sdo_format" configuration parameter that could make it easier to generate a spec in an IETF-style to simplify the preparation of and Internet Draft.