### PR TITLE
Change in chairs

### DIFF
--- a/3._Notices.md
+++ b/3._Notices.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-Contact for [Code of Conduct](8._Code_of_Conduct.md) issues or inquires: Stephen Curran [swcurran@cloudcompass.ca](mailto:swcurran@cloudcompass.ca), Matt Raffel [mattr@kiva.org](mailto:mattr@kiva.org)
+Contact for [Code of Conduct](8._Code_of_Conduct.md) issues or inquires: Stephen Curran [swcurran@cloudcompass.ca](mailto:swcurran@cloudcompass.ca).
 
 ## License Acceptance
 

--- a/spec/acknowledgements_authors.md
+++ b/spec/acknowledgements_authors.md
@@ -9,6 +9,7 @@ contributed ideas, feedback, and wording that influenced this specification:
 
 * Artur Philipp - IDUnion
 * Hakan Yildiz - Technische Universität Berlin
+* Matt Raffel - Kiva Microfiance
 
 ## Authors' Addresses
 

--- a/spec/header.md
+++ b/spec/header.md
@@ -10,7 +10,6 @@ AnonCreds Specification
 **Editors:**
 
 - [Stephen Curran](https://github.com/swcurran)
-- [Matt Raffel](https://github.com/matt-raffel-kiva)
 - Hakan Yaldiz
 - Sam Curran
 - Victor Martinez Jurado


### PR DESCRIPTION
Signed-off-by: Matt Raffel <mattr@kiva.org>

Due to some changes out of my control, I will step away from co-chair of this group.  Looking forward to continuing to work with the group; hopefully start of y2023