### PR TITLE
Add crypto section to generated spec

### DIFF
--- a/spec/crypto.md
+++ b/spec/crypto.md
@@ -18,7 +18,7 @@ _TODO: clarify exact format and encoding of inputs and outputs_
 
 `ProveCLCommit` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1313-L1394).
 
-```tex
+```
 
 ( A', v', e', Z~, e~, v~ ) = ProveCLCommit( PK, signature, (m_1,..., m_L), RevealedIndexes, R )
 
@@ -89,7 +89,7 @@ Procedure:
 
 `ProveCLResponse` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1533-L1633).
 
-```tex
+```
 pi = ProveCLResponse( (m_1,..., m_L), RevealedIndexes, R, c, ( A', v', e', Z~, e~, v~ ) )
 
 Inputs:

--- a/spec/crypto.md
+++ b/spec/crypto.md
@@ -19,7 +19,6 @@ _TODO: clarify exact format and encoding of inputs and outputs_
 `ProveCLCommit` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1313-L1394).
 
 ```
-
 ( A', v', e', Z~, e~, v~ ) = ProveCLCommit( PK, signature, (m_1,..., m_L), RevealedIndexes, R )
 
 Inputs:
@@ -88,6 +87,7 @@ Procedure:
 ```
 
 `ProveCLResponse` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1533-L1633).
+
 
 ```
 pi = ProveCLResponse( (m_1,..., m_L), RevealedIndexes, R, c, ( A', v', e', Z~, e~, v~ ) )

--- a/spec/crypto.md
+++ b/spec/crypto.md
@@ -18,7 +18,8 @@ _TODO: clarify exact format and encoding of inputs and outputs_
 
 `ProveCLCommit` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1313-L1394).
 
-```
+```tex
+
 ( A', v', e', Z~, e~, v~ ) = ProveCLCommit( PK, signature, (m_1,..., m_L), RevealedIndexes, R )
 
 Inputs:
@@ -88,8 +89,7 @@ Procedure:
 
 `ProveCLResponse` finds has its reference implementation [here](https://github.com/hyperledger/ursa/blob/ece6ce32a59df4e1f99fa38243c1236423066bc2/libursa/src/cl/prover.rs#L1533-L1633).
 
-
-```
+```tex
 pi = ProveCLResponse( (m_1,..., m_L), RevealedIndexes, R, c, ( A', v', e', Z~, e~, v~ ) )
 
 Inputs:

--- a/specs.json
+++ b/specs.json
@@ -20,6 +20,7 @@
         "data_flow_presentation_create_presentation.md",
         "data_flow_presentation_verify.md",
         "data_flow_revocation.md",
+        "crypto.md",
         "anoncreds_conventions.md",
         "iana_considerations.md",
         "security_considerations.md",


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

The crypto.md file merged previously was not being referenced in the "specs.json" file, so was not being generated into the spec.  This change puts it into the spec.

~~In doing that, I discovered that the generated text looks pretty bad (red text...) as a block, so I added a type on the text block.~~

~~@ale-linux -- this will probably mess up your PR #55 because of the addition of the text blocks.~~