### PR TITLE
Add definition for DIDs and how they are used in AnonCreds

### DIFF
--- a/spec/data_flow_setup.md
+++ b/spec/data_flow_setup.md
@@ -69,22 +69,24 @@ sequenceDiagram
 
 Those with a knowledge of DIDs might expect that in the flow above, the first
 step would be for the [[ref: issuer]] to publish a DID. However, in AnonCreds,
-DIDs are not used in the processing of credentials, but rather are used to
-identify the entity publishing the objects used in the processing of credentials
--- the [[def: SCEHMA]], [[def: CRED_DEF]], [[def: REV_REG_DEF]] and [[def:
-REV_REG_ENTRY]] objects. That is, there is an enforced relationship between the
-DID of the entity publishing the AnonCred objects, and the objects themselves.
-For example, in the Hyperledger Indy implementation of AnonCreds, for a
-credential issuer to publish a [[def: CRED_DEF]] on an instance of Indy it must
-have a DID on that instance, and it must use that DID to sign the transaction to
-write the [[def: CRED_DEF]].
+DIDs are not used in the processing of credentials, and notably, the public keys
+used in AnonCreds signatures come not from DIDs, but rather from [[def:
+CRED_DEF]] objects. DIDs may be used to identify the entity publishing the
+objects that are then used in the processing of credentials -- the [[def:
+SCEHMA]], [[def: CRED_DEF]], [[def: REV_REG_DEF]] and [[def: REV_REG_ENTRY]]
+objects. There is an enforced relationship between an identifier (such as a DID)
+for the entity publishing the AnonCred objects, and the objects themselves. For
+example, in the Hyperledger Indy implementation of AnonCreds, for a credential
+issuer to publish a [[def: CRED_DEF]] on an instance of Indy it must have a DID
+on that instance, and it must use that DID to sign the transaction to write the
+[[def: CRED_DEF]].
 
 The DID of the publisher of an AnonCreds object MUST be identifiable from the
 published object and enforcement of the relationship between the DID and the
 object must be enforced. For example, in the Hyperledger Indy implementation of
 AnonCreds, the DID of the object publisher is part of the identifier of the
 object -- given the identifier for the AnonCreds object (e.g. one found in
-proofing a verifiable credential), the DID of the publisher can be found.
+proving a verifiable credential), the DID of the publisher can be found.
 Further, the Hyperledger Indy ledger enforces, and makes available for
 verification, the requirement that the writing of the AnonCreds object must be
 signed by the DID that is writing the object.
@@ -92,9 +94,10 @@ signed by the DID that is writing the object.
 If a DID-based messaging protocol, such as
 [DIDComm](https://identity.foundation/didcomm-messaging/spec/) is used between
 the AnonCreds participants (the [[ref: issuer]], [[ref: holder]] and [[ref:
-verifier]]) the DIDs used for messaging are not used at all in AnonCreds. Such
-DIDs are used only to facilitate secure messaging between the participants to
-enable the issuing of credentials and the presentation of proofs.
+verifier]]) the use of DIDs for messaging is independent of their use (or not)
+in the publishing AnonCreds objects. Such DIDs are used to facilitate secure
+messaging between the participants to enable the issuing of credentials and the
+presentation of proofs.
 
 :::
 

--- a/spec/data_flow_setup.md
+++ b/spec/data_flow_setup.md
@@ -28,10 +28,6 @@ Each of the aforementioned data flows involve different data objects and actors,
 
 The following sequence diagram summarizes the setup operations performed by a [[ref: SCHEMA Publisher]], the [[ref: Issuer]] (one required and one optional) in preparing to issue an AnonCred credential based on provided [[ref: SCHEMA]], and the one setup operation performed by each [[ref: Holder]]. On successfully completing the operations, the [[ref: Issuer]] is able to issue credentials based on the given [[ref: SCHEMA]] to the [[ref: Holder]]. The subsections below the diagram detail each of these operations.
 
-::: todo
-Question: Should there be an operation to cover creating the published DID for the SCHEMA Publisher and Issuer?
-:::
-
 ```mermaid
 sequenceDiagram
     autonumber
@@ -68,6 +64,39 @@ sequenceDiagram
       Note left of H: 💡The "Verifier" role is<br>omitted in this<br>diagram, since<br>it is not required<br>for the setup
     end
 ```
+
+::: note
+
+Those with a knowledge of DIDs might expect that in the flow above, the first
+step would be for the [[ref: issuer]] to publish a DID. However, in AnonCreds,
+DIDs are not used in the processing of credentials, but rather are used to
+identify the entity publishing the objects used in the processing of credentials
+-- the [[def: SCEHMA]], [[def: CRED_DEF]], [[def: REV_REG_DEF]] and [[def:
+REV_REG_ENTRY]] objects. That is, there is an enforced relationship between the
+DID of the entity publishing the AnonCred objects, and the objects themselves.
+For example, in the Hyperledger Indy implementation of AnonCreds, for a
+credential issuer to publish a [[def: CRED_DEF]] on an instance of Indy it must
+have a DID on that instance, and it must use that DID to sign the transaction to
+write the [[def: CRED_DEF]].
+
+The DID of the publisher of an AnonCreds object MUST be identifiable from the
+published object and enforcement of the relationship between the DID and the
+object must be enforced. For example, in the Hyperledger Indy implementation of
+AnonCreds, the DID of the object publisher is part of the identifier of the
+object -- given the identifier for the AnonCreds object (e.g. one found in
+proofing a verifiable credential), the DID of the publisher can be found.
+Further, the Hyperledger Indy ledger enforces, and makes available for
+verification, the requirement that the writing of the AnonCreds object must be
+signed by the DID that is writing the object.
+
+If a DID-based messaging protocol, such as
+[DIDComm](https://identity.foundation/didcomm-messaging/spec/) is used between
+the AnonCreds participants (the [[ref: issuer]], [[ref: holder]] and [[ref:
+verifier]]) the DIDs used for messaging are not used at all in AnonCreds. Such
+DIDs are used only to facilitate secure messaging between the participants to
+enable the issuing of credentials and the presentation of proofs.
+
+:::
 
 #### SCHEMA Publisher: Publish SCHEMA Object
 

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -19,7 +19,32 @@
 ~ TODO
 
 [[def: DID]]
-~ TODO
+
+~ A Decentralized Identifier (DID), defined by the [W3C DID Core
+Specification](https://w3c.github.io/did-core/), is a type of identifier that
+enables verifiable, decentralized digital identity. A DID refers to any subject
+(e.g., a person, organization, thing, data model, abstract entity, etc.) as
+determined by the controller of the DID.
+
+~ In AnonCreds, DIDs are not used directly in the processing of credentials, but
+rather are used to identify the entity publishing the objects used in the
+processing of credentials -- the [[def: SCEHMA]], [[def: CRED_DEF]], [[def:
+REV_REG_DEF]] and [[def: REV_REG_ENTRY]] objects. That is, there is an enforced
+relationship between the DID of the entity publishing the AnonCred objects, and
+the objects themselves. For example, in the Hyperledger Indy implementation of
+AnonCreds, for a credential issuer to publish a [[def: CRED_DEF]] on an instance
+of Indy it must have a DID on that instance, and it must use that DID to sign
+the transaction to write the [[def: CRED_DEF]].
+
+~ The DID of the publisher of an AnonCreds object MUST be identifiable from the
+published object and enforcement of the relationship between the DID and the
+object must be enforced. For example, in the Hyperledger Indy implementation of
+AnonCreds, the DID of the object publisher is part of the identifier of the
+object -- given the identifier for the AnonCreds object (e.g. one found in
+proofing a verifiable credential), the DID of the publisher can be found.
+Further, the Hyperledger Indy ledger enforces, and makes available for
+verification, the requirement that the writing of the AnonCreds object must be
+signed by the DID that is writing the object.
 
 [[def: nonce]]
 ~ TODO

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -24,27 +24,11 @@
 Specification](https://w3c.github.io/did-core/), is a type of identifier that
 enables verifiable, decentralized digital identity. A DID refers to any subject
 (e.g., a person, organization, thing, data model, abstract entity, etc.) as
-determined by the controller of the DID.
-
-~ In AnonCreds, DIDs are not used directly in the processing of credentials, but
-rather are used to identify the entity publishing the objects used in the
-processing of credentials -- the [[def: SCEHMA]], [[def: CRED_DEF]], [[def:
-REV_REG_DEF]] and [[def: REV_REG_ENTRY]] objects. That is, there is an enforced
-relationship between the DID of the entity publishing the AnonCred objects, and
-the objects themselves. For example, in the Hyperledger Indy implementation of
-AnonCreds, for a credential issuer to publish a [[def: CRED_DEF]] on an instance
-of Indy it must have a DID on that instance, and it must use that DID to sign
-the transaction to write the [[def: CRED_DEF]].
-
-~ The DID of the publisher of an AnonCreds object MUST be identifiable from the
-published object and enforcement of the relationship between the DID and the
-object must be enforced. For example, in the Hyperledger Indy implementation of
-AnonCreds, the DID of the object publisher is part of the identifier of the
-object -- given the identifier for the AnonCreds object (e.g. one found in
-proofing a verifiable credential), the DID of the publisher can be found.
-Further, the Hyperledger Indy ledger enforces, and makes available for
-verification, the requirement that the writing of the AnonCreds object must be
-signed by the DID that is writing the object.
+determined by the controller of the DID. DIDs are not used in AnonCreds itself
+but there must be an DID-based, enforced relationship between the [[ref: schema
+publishers]] and [[ref: issuers]] and the AnonCreds objects they publish. This
+is outlined in a note in [this section](anoncreds-setup-data-flow) of this
+specification.
 
 [[def: nonce]]
 ~ TODO


### PR DESCRIPTION
Addresses https://github.com/AnonCreds-WG/anoncreds-spec/issues/52 -- documenting how DIDs are used AnonCreds.

Added by putting in a definition [[def: DID]] and then including in the definition a description of how DIDs are used. Not sure if that is right -- could move that to another section.

If you think the part about how DIDs are used/not used should move -- let me know where you think they should go. 😄
