### PR TITLE
doc: Cred key correctness proof and blinding hidden values

### DIFF
--- a/spec/data_flow_issuance.md
+++ b/spec/data_flow_issuance.md
@@ -71,8 +71,42 @@ A [[ref:Credential Request]] is a formal request from a [[ref:holder]] to an [[r
 
 In order to be able as a [[ref:holder]] to express within a [[ref:Credential Request]] to the [[ref:issuer]] which kind of credential the [[ref:issuer]] shall issue to the [[ref:holder]], the [[ref:holder]] requires the [[ref:CRED_DEF]] from the [[ref:Verifiable Data Registry]] if not already available in local storage (step 6 + 7). The [[ref:Credential Request]] has to reference the same [[ref:CRED_DEF]] and [[ref:nonce]] as given in the preceding [[ref:Credential Offer]]. Besides the [[ref:CRED_DEF]], the [[ref:holder]] also requires his [[ref:link secret]] in a blinded form, as well as the corresponding [[ref: Correctness Proof]] of his [[ref:link secret]]. The [[ref: holder]] has now all relevant data for creating the [[ref:Credential Request]] (step 8).
 
+#### Blinding hidden attributes
+
+The [[ref: link secret]] is a default hidden attribute.
+The blinding process is done specifically for an issuer's specific [[ref:CRED_DEF]].
+The `blinded_secrets` sent to the issuer includes:
+
+*- the aggregated values of all blinded hidden attributes
+*- the hidden attrbute key values
+*- the [[ref:Correctness Proof]]
+
+A `blinding factory` is used as a secret held by the [[ref:holder]] for blinding the hidden attributes before sending it to issuer and to unblind the signed values in the signature received from the issuer.
+
+A `CredentialPrimaryPublicKey`, $P$, is a field in the [[ref:CRED_DEF]] in the form of CL Signatures and it is defined by:
+
+```json
+{
+    n: BigNumber,
+    s: BigNumber,
+    r: HashMap<string /* attr_name */, BigNumber>,
+    rctxt: BigNumber,
+    z: BigNumber,
+}
+```
+
+Each hidden attributed, $h_i$ is blinded by
+
+$bh_i = P_r^{h_i} mod P_n$
+
+The product of all $bh_i$ is multiplied by the `blinding factory`, $v$, by
+
+$(P_s^v \times \prod_{i=0}^{i=l}bh_i)Mod P_n$
+
+This means that all hidden attributes produce one value before provided to the issuer to sign.
+
 ::: todo
-- Add here: How does the link secret get blinded? How does the cryptography work? How does it work with correctness proof? 
+*- How does the cryptography work? How does it work with correctness proof?
 :::
 
 The resulting JSON for a created [[ref:Credential Request]] is shown here:

--- a/spec/data_flow_issuance.md
+++ b/spec/data_flow_issuance.md
@@ -71,10 +71,15 @@ A [[ref:Credential Request]] is a formal request from a [[ref:holder]] to an [[r
 
 In order to be able as a [[ref:holder]] to express within a [[ref:Credential Request]] to the [[ref:issuer]] which kind of credential the [[ref:issuer]] shall issue to the [[ref:holder]], the [[ref:holder]] requires the [[ref:CRED_DEF]] from the [[ref:Verifiable Data Registry]] if not already available in local storage (step 6 + 7). The [[ref:Credential Request]] has to reference the same [[ref:CRED_DEF]] and [[ref:nonce]] as given in the preceding [[ref:Credential Offer]]. Besides the [[ref:CRED_DEF]], the [[ref:holder]] also requires his [[ref:link secret]] in a blinded form, as well as the corresponding [[ref:Blinded Secrets Correctness Proof]] of his [[ref:link secret]]. The [[ref: holder]] has now all relevant data for creating the [[ref:Credential Request]] (step 8).
 
+The blinding process requires the target [[ref: CRED_DEF]] to construct the blinded secret and the [[ref: Blinded Secrets Correctness Proof]].
+The [[ref:holder]] should ensure that the blinded secret is unique per request by producing unique [[ref:blinding factor]] every time.
+
 #### Check Credential Key Correctness Proof
 
-The blinding process is done specifically for an issuer's specific [[ref:CRED_DEF_PUBLIC]], therefore it is importatnt for the [[ref:holder]] to check if the [[ref:Credential Key Correctness Proof]] matched the [[ref:CRED_DEF]] retrievable from the [[ref: Credential Offer]]
+It is important to ensure that[[ref:CRED_DEF_PUBLIC]] used in the blinding process is the intended public key,
+otherwise, the received signature from the [[ref:issuer]] will not be valid when generating presentation.
 
+Therefore, the [[ref:holder]] first checks if the [[ref:Credential Key Correctness Proof]] matches the [[ref:CRED_DEF]] retrievable from the [[ref: Credential Offer]].
 The [[ref: Credential Key Correctness Proof]] is prepared by the [[ref: issuer]] when creating the [[ref: CRED_DEF]].
 
 The proof has the following format:
@@ -111,17 +116,18 @@ The check is done as follows:
 
 $$c' = H(z || {r_i}  || \hat{z'} ||\hat{r_i'})$$
 
-where we first fist the inverse of $z$
+where we first find the inverse of $z$
 $$ z^{-1}z = 1\ (Mod\ n) $$
 
-Then 
+Then
 $$ \hat{z'} = z^{-c} s^{\hat{x_z}} \ (Mod\ n)$$
 $$= z^{-c} s^{cx_z + \~{x_z}}\ (Mod\ n)$$
 $$= z^{-c} z^{c}  s^{\~{x_z}}\ (Mod\ n)$$
 
 $$ \hat{z'} = \~z$$
 
-Therefore $c'$ is equivalent to $c$ if the proof matches the [[ref:CRED_DEF_PUBLIC]] by simply using modular inverse of $z$ and $r_i$. Since the process is same for both, we have demonstrated for $z$ only.  
+Therefore $c'$ is equivalent to $c$ if the proof matches the [[ref:CRED_DEF_PUBLIC]] by simply using the multiplicative inverse of $z$ and $r_i$. 
+Since the process is same for both, we have demonstrated for $z$ only.  
 
 #### Blinding Link Secret
 
@@ -130,7 +136,7 @@ Whilst it is cryptographically possible to have multiple hidden attributes,
 in AnonCreds,
 only [[ref:link secret]] is used.
 
-A `blinding factor` is used as a secret held by the [[ref:holder]] for blinding the [[ref:link secret]] before sending it to issuer and to unblind the signed values in the signature received from the issuer.
+A [[ref:blinding factor]] is used as a secret held by the [[ref:holder]] for blinding the [[ref:link secret]] before sending it to issuer and to unblind the signed values in the signature received from the issuer.
 
 The process of blinding uses the [[ref:issuer]]'s `CredentialPrimaryPublicKey`, $P$,
 which is included in the [[ref:CRED_DEF_PUBLIC]] containing
@@ -142,7 +148,7 @@ The [[ref:link secret]], $A_l$ is blinded by
 
 $A_{bl} = r_{link_secret}^{A_l}\ Mod\ n$
 
-$A_{bl}$ is multiplied by the `blinding factory`, $v$,
+$A_{bl}$ is multiplied by the [[ref:blinding factor]], $v$,
 
 $(s^v \times A_{bl})\ Mod\ n$
 

--- a/spec/data_flow_issuance.md
+++ b/spec/data_flow_issuance.md
@@ -39,7 +39,7 @@ The [[ref:issuer]] can decide whether to accept the received [[ref: Credential R
 
 ### Credential Offer
 
-Before issuing a credential to the [[ref:holder]], the [[ref:issuer]] has to send a [[ref:Credential Offer]] to the potential [[ref:holder]] (step 1 and 2). A [[ref:Credential Offer]] contains information about the credential the [[ref:issuer]] intends to issue and send to the [[ref:holder]]. For creating a [[ref:Credential Offer]], the [[ref:issuer]] is required to fetch the [[ref:CRED_DEF]] as well as its correctness proof from the [[ref: Verifiable Data Registry]]. The [[ref:issuer]] also prepares a [[ref:nonce]] which will be embedded within the [[ref:Credential Offer]] in order to prevent replay attacks and authenticate between protocol steps.
+Before issuing a credential to the [[ref:holder]], the [[ref:issuer]] has to send a [[ref:Credential Offer]] to the potential [[ref:holder]] (step 1 and 2). A [[ref:Credential Offer]] contains information about the credential the [[ref:issuer]] intends to issue and send to the [[ref:holder]]. For creating a [[ref:Credential Offer]], the [[ref:issuer]] is required to fetch the [[ref:CRED_DEF]] as well as its [[ref:Credential Key Correctness Proof]] from the [[ref: Verifiable Data Registry]]. The [[ref:issuer]] also prepares a [[ref:nonce]] which will be embedded within the [[ref:Credential Offer]] in order to prevent replay attacks and authenticate between protocol steps.
 
 The resulting JSON for a created [[ref:Credential Offer]] is shown here:
 
@@ -173,7 +173,7 @@ is the ```prover_did``` the peer DID of the holder?
 * `prover_did`: The [[ref:DID]] of the [[ref:holder]].
 * `cred_def_id`: The ID of the [[ref:CRED_DEF]] on which the [[ref:Credential]] to be issued shall be based.
 * `blinded_ms`: The [[ref:link secret]] in its blinded form.
-* `blinded_ms_correctness_proof`: The [[ref: Correctness Proof]] of the blinded [[ref:link secret]].
+* `blinded_ms_correctness_proof`: The [[ref: Blinded Secrets Correctness Proof]] of the blinded [[ref:link secret]].
 * `nonce`: Used for preventing replay attacks and authentication between protocol steps. Reused from the initially received [[ref:Credential Offer]].
 
 The [[ref:issuer]] sends the [[ref:Credential Request]] to the [[ref:issuer]] (step 9), who then can reply to the [[ref:holder]] by sending an issued credential.
@@ -186,7 +186,7 @@ In case the [[ref:issuer]] decides to issue the requested credential to the [[re
 
 :::todo
 - check nonce?
-- check link secret and correctness proof?
+- check link secret and blinded secrets correctness proof?
 :::
 
 1. The [[ref:issuer]] has to fetch the [[ref:CRED_DEF]] for the `cred_def_id` given in the received [[ref:Credential Request]] either from the ledger or local storage (if already available).
@@ -277,7 +277,7 @@ The [[ref:issuer]] has to transmit the whole credential data to the [[ref:holder
 * `cred_def_id`: The ID of the [[ref:CRED_DEF]] on which the [[ref:Credential]] issued is based.
 * `values`: The raw and encoded credential attribute values as JSON (cred_values_json).
 * `signature`: The signatures of the separately signed attributes
-* `signature_correctness_proof`: The signature correctness proof of the signature for the whole credential data.
+* `signature_correctness_proof`: The [[ref: Signature Correctness Proof]] of the signature for the whole credential data.
 * `rev_reg`: The revocation registry ID of the revocation registry, the issued credentials is assigned.
 * `witness`: Witness information. (See Revocation)
 

--- a/spec/data_flow_issuance.md
+++ b/spec/data_flow_issuance.md
@@ -71,19 +71,24 @@ A [[ref:Credential Request]] is a formal request from a [[ref:holder]] to an [[r
 
 In order to be able as a [[ref:holder]] to express within a [[ref:Credential Request]] to the [[ref:issuer]] which kind of credential the [[ref:issuer]] shall issue to the [[ref:holder]], the [[ref:holder]] requires the [[ref:CRED_DEF]] from the [[ref:Verifiable Data Registry]] if not already available in local storage (step 6 + 7). The [[ref:Credential Request]] has to reference the same [[ref:CRED_DEF]] and [[ref:nonce]] as given in the preceding [[ref:Credential Offer]]. Besides the [[ref:CRED_DEF]], the [[ref:holder]] also requires his [[ref:link secret]] in a blinded form, as well as the corresponding [[ref: Correctness Proof]] of his [[ref:link secret]]. The [[ref: holder]] has now all relevant data for creating the [[ref:Credential Request]] (step 8).
 
-#### Blinding hidden attributes
+#### Blinding Link Secret
 
-The [[ref: link secret]] is a default hidden attribute.
+The [[ref:link secret]] is a default hidden attribute.
+Whilst it is cryptographically possible to have multiple hidden attributes,
+in AnonCreds,
+only [[ref:link secret]] is used.
+
 The blinding process is done specifically for an issuer's specific [[ref:CRED_DEF]].
-The `blinded_secrets` sent to the issuer includes:
+The data included in the [[ref:Credential Request]] sent to the issuer includes:
 
-*- the aggregated values of all blinded hidden attributes
-*- the hidden attrbute key values
+*- the blinded [[ref:link secret]]
+*- the hidden attrbute key, aka [[ref:link secret]]
 *- the [[ref:Correctness Proof]]
 
-A `blinding factory` is used as a secret held by the [[ref:holder]] for blinding the hidden attributes before sending it to issuer and to unblind the signed values in the signature received from the issuer.
+A `blinding factor` is used as a secret held by the [[ref:holder]] for blinding the [[ref:link secret]] before sending it to issuer and to unblind the signed values in the signature received from the issuer.
 
-A `CredentialPrimaryPublicKey`, $P$, is a field in the [[ref:CRED_DEF]] in the form of CL Signatures and it is defined by:
+The process of blinding uses the [[ref:issuer]]'s `CredentialPrimaryPublicKey`, $P$,
+which is included in the [[ref:CRED_DEF]] and it is defined by:
 
 ```json
 {
@@ -95,15 +100,13 @@ A `CredentialPrimaryPublicKey`, $P$, is a field in the [[ref:CRED_DEF]] in the f
 }
 ```
 
-Each hidden attributed, $h_i$ is blinded by
+The [[ref:link secret]], $A_l$ is blinded by
 
-$bh_i = P_r^{h_i} mod P_n$
+$A_{bl} = P_r^{A_l} mod P_n$
 
-The product of all $bh_i$ is multiplied by the `blinding factory`, $v$, by
+$A_{bl}$ is multiplied by the `blinding factory`, $v$,
 
-$(P_s^v \times \prod_{i=0}^{i=l}bh_i)Mod P_n$
-
-This means that all hidden attributes produce one value before provided to the issuer to sign.
+$(P_s^v \times A_{bl})Mod P_n$
 
 ::: todo
 *- How does the cryptography work? How does it work with correctness proof?

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -3,10 +3,12 @@
 [[def: claim, claims]]
 ~ A claim is a part of digital identity related to a [[ref: subject]]. A claim can be attested by the identity subject itself, or it can be asserted by another entity. 
 
-[[def: Correctness Proof]]
-~ TODO
+[[def: Credential Key Correctness Proof]]
+~  This is produced during the creation of the [[ref: CRED_DEF]] and is included in the [[ref: Credential Offer]] so that the [[ref:holder]] can verify that the [[ref::CRED_DEF_PUBLIC]] used in the blinding process belongs to the [[ref:issuer]].
+
 ::: todo
-Describe (key) Correctness Proof
+[[def: Signature Correctness Proof]]
+[[def: Blinded Secrets Correctness Proof]]
 :::
 
 [[def: credential, credentials]]
@@ -22,7 +24,7 @@ Describe (key) Correctness Proof
 ~ Revokable Verifiable Credentials require (besides) a CRED_DEF also a [[ref: REV_REG_DEF]].
 
 [[def: Credential Offer]]
-~ A credential offer is an offering from an [[ref: issuer ]] towards a [[ref: holder]] to issue a [[ref: credential]]. The credential offer contains the details about the claims the [[ref: issuer]] intends to issue to the [[ref: holder]]. A [[ref: holder]] can reply to the [[ref: issuer]] with a [[ref: Credential Request]]. A credential offer also includes a [[ref: nonce]].
+~ A credential offer is an offering from an [[ref: issuer ]] towards a [[ref: holder]] to issue a [[ref: credential]]. The credential offer contains the details about the claims the [[ref: issuer]] intends to issue to the [[ref: holder]]. A [[ref: holder]] can reply to the [[ref: issuer]] with a [[ref: Credential Request]]. A credential offer also includes a [[ref: nonce]] and a [[ref: Credential Key Correctness Proof]].
 
 [[def: Credential Request]]
 ~ A credential request is a request from an [[ref: holder]] towards a [[ref: issuer]] to get a credential issued by the [[ref: issuer]]. The credential request references a preceding [[ref: Credential offer]] and defines the claims the [[ref: holder]] wants to get issued. A credential request also includes a [[ref: nonce]].

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -1,5 +1,9 @@
 ## Terminology
 
+::: todo
+[[def: blinding factor]]
+:::
+
 [[def: claim, claims]]
 ~ A claim is a part of digital identity related to a [[ref: subject]]. A claim can be attested by the identity subject itself, or it can be asserted by another entity. 
 


### PR DESCRIPTION
- added how libursa currently manages the blinding of all hidden attributes (including link secret)

I am aware that only 1 hidden attribute, link_secret, is used, however, it is possible to have more. 
Right now unsure as to how multiple hidden attributes are useful. 

